### PR TITLE
v0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![PyPI version](https://badge.fury.io/py/wavpack-numcodecs.svg)](https://badge.fury.io/py/wavpack-numcodecs) ![tests](https://github.com/AllenNeuralDynamics/wavpack-numcodecs/actions/workflows/python-package-cython.yml/badge.svg)
+
+
 # WavPack - numcodecs implementation
 
 [Numcodecs](https://numcodecs.readthedocs.io/en/latest/index.html) wrapper to the 

--- a/wavpack_numcodecs/version.py
+++ b/wavpack_numcodecs/version.py
@@ -1,1 +1,1 @@
-version = "0.1.2"
+version = "0.1.3"


### PR DESCRIPTION
Fixes decompression errors by pre-determining the decompression buffer size from the encoded data #9 